### PR TITLE
Se sube la versión actual del Memory Profiler.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,22 +1,17 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(memory_profiler
-  VERSION 0.1.0
-  LANGUAGES CXX)
+project(memory_profiler VERSION 0.1.0 LANGUAGES CXX)
 
-# Recomendado para diagnósticos de memoria
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)  # -fPIC para librerías
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# Opciones de build por defecto si no se especifica
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "Build type" FORCE)
 endif()
 
-# Recoger fuentes de la librería (ajusta la ruta si tus .cpp están en otro lugar)
-file(GLOB_RECURSE MEMORY_PROFILER_SOURCES
-     CONFIGURE_DEPENDS
+# 1) Fuentes de la LIB (solo Library/, NO GUI aquí)
+file(GLOB_RECURSE MEMORY_PROFILER_SOURCES CONFIGURE_DEPENDS
      src/Library/*.cpp)
 
 if(MEMORY_PROFILER_SOURCES STREQUAL "")
@@ -25,29 +20,51 @@ endif()
 
 add_library(memory_profiler STATIC ${MEMORY_PROFILER_SOURCES})
 
-# Incluye los headers públicos (ajusta si tus headers están en otra carpeta)
+# 2) INCLUDES públicos de la LIB (para que vea BlockInfo.hpp, ProfilerAPI.hpp, Callbacks.hpp)
 target_include_directories(memory_profiler
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/Library/include>
-    $<INSTALL_INTERFACE:include>)
+    $<INSTALL_INTERFACE:include>
+)
 
 target_compile_features(memory_profiler PUBLIC cxx_std_17)
 
-# Warnings útiles y frame pointers para mejores perfiles
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
   target_compile_options(memory_profiler PRIVATE
     -Wall -Wextra -Wpedantic -Wconversion
     -fno-omit-frame-pointer)
 endif()
 
-# pthread si lo usas (bloqueos, TLS, etc.)
 find_package(Threads REQUIRED)
 target_link_libraries(memory_profiler PUBLIC Threads::Threads)
 
-# (Opcional) defines para evitar recursión en hooks u opciones de la lib
-# target_compile_definitions(memory_profiler PUBLIC MP_ENABLE_DEMANGLE=1)
+# === Opcional: ejemplo CLI para probar rápidamente ===
+option(MP_BUILD_EXAMPLES "Build examples" ON)
+if (MP_BUILD_EXAMPLES)
+  add_executable(mp_demo examples/demo.cpp)
+  target_link_libraries(mp_demo PRIVATE memory_profiler)
+  target_compile_features(mp_demo PRIVATE cxx_std_17)
+endif()
 
-# (Opcional) Instalar la librería y headers
-# install(TARGETS memory_profiler EXPORT memory_profilerTargets
-#         ARCHIVE DESTINATION lib)
+# === Opcional: construir GUI como ejecutable aparte ===
+option(MP_BUILD_GUI "Build GUI" OFF)
+if (MP_BUILD_GUI)
+  add_executable(mp_gui
+    src/GUI/core/main_gui.cpp
+    src/GUI/core/GUI.cpp
+    src/GUI/core/Views.cpp
+    src/GUI/core/Charts.cpp
+    src/GUI/core/SocketServer.cpp
+  )
+  target_include_directories(mp_gui PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/GUI/include
+  )
+  target_link_libraries(mp_gui PRIVATE memory_profiler Threads::Threads)
+  if (WIN32)
+    target_link_libraries(mp_gui PRIVATE ws2_32)
+  endif()
+endif()
+
+# (Opcional) instalación
+# install(TARGETS memory_profiler EXPORT memory_profilerTargets ARCHIVE DESTINATION lib)
 # install(DIRECTORY src/Library/include/ DESTINATION include)

--- a/examples/demo.cpp
+++ b/examples/demo.cpp
@@ -23,13 +23,18 @@ static Blob* make_blob(size_t sz) {
     return MP_NEW_FT(Blob, sz);
 }
 
+namespace mp { void install_callbacks_with_memorytracker(); }
+
+
 int main() {
+
+    mp::install_callbacks_with_memorytracker();
     // 1) Arranca el cliente para hablar con la GUI (127.0.0.1:7777 por defecto)
     static mp::SocketClient client;
     client.start("127.0.0.1", 7777);
 
     std::cout << "[demo] starting... metrics(before)="
-              << mp::api::getMetricsJson() << "\n";
+            << mp::api::getMetricsJson() << "\n";
 
     std::mt19937_64 rng{123456789};
     std::uniform_int_distribution<size_t> size_dist(1<<10, 1<<15); // 1 KB .. 32 KB

--- a/src/Library/core/BlockInfo.cpp
+++ b/src/Library/core/BlockInfo.cpp
@@ -1,3 +1,17 @@
-//
-// Created by PC MASTER on 8/25/2025.
-//
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+namespace mp {
+
+// DTO público que serializa Serializer.{csv,json}
+struct BlockInfo {
+    void*         ptr        = nullptr;      // dirección
+    std::size_t   size       = 0;            // bytes
+    std::uint64_t alloc_id   = 0;            // id único incremental
+    std::uint32_t thread_id  = 0;            // id de hilo (hash truncado)
+    std::uint64_t t_ns       = 0;            // timestamp ns (steady_clock)
+    std::string   callsite;                  // "file:line[:func]" ya formateado
+};
+
+} // namespace mp

--- a/src/Library/core/Callbacks.cpp
+++ b/src/Library/core/Callbacks.cpp
@@ -1,0 +1,36 @@
+#include "Callbacks.hpp"
+#include <mutex>
+
+namespace mp {
+
+  static Callbacks g_cb;
+  static std::once_flag g_init_once;
+
+  static void init_noop() {
+    g_cb.onAlloc    = [](void*, std::size_t, const char*){};
+    g_cb.onFree     = [](void*){};
+    g_cb.bytesInUse = []{ return std::size_t(0); };
+    g_cb.peakBytes  = []{ return std::size_t(0); };
+    g_cb.allocCount = []{ return std::size_t(0); };
+    g_cb.snapshot   = []{ return std::uint64_t(0); };
+    g_cb.liveBlocks = []{ return std::vector<BlockInfo>{}; };
+  }
+
+  void register_callbacks(const Callbacks& c) {
+    std::call_once(g_init_once, init_noop);
+    g_cb = c;
+    if (!g_cb.onAlloc)    g_cb.onAlloc    = [](void*, std::size_t, const char*){};
+    if (!g_cb.onFree)     g_cb.onFree     = [](void*){};
+    if (!g_cb.bytesInUse) g_cb.bytesInUse = []{ return std::size_t(0); };
+    if (!g_cb.peakBytes)  g_cb.peakBytes  = []{ return std::size_t(0); };
+    if (!g_cb.allocCount) g_cb.allocCount = []{ return std::size_t(0); };
+    if (!g_cb.snapshot)   g_cb.snapshot   = []{ return std::uint64_t(0); };
+    if (!g_cb.liveBlocks) g_cb.liveBlocks = []{ return std::vector<BlockInfo>{}; };
+  }
+
+  const Callbacks& get_callbacks() {
+    std::call_once(g_init_once, init_noop);
+    return g_cb;
+  }
+
+} // namespace mp

--- a/src/Library/core/CallbacksRegistration.cpp
+++ b/src/Library/core/CallbacksRegistration.cpp
@@ -1,0 +1,64 @@
+#include "Callbacks.hpp"
+#include "MemoryTracker.hpp"
+#include "BlockInfo.hpp"
+#include "Callsite.hpp"
+#include "ReentryGuard.hpp"
+#include <atomic>
+#include <vector>
+#include <string>
+
+namespace mp {
+
+static std::atomic<std::uint64_t> g_alloc_id{0};
+static std::atomic<std::uint64_t> g_snapshot_id{0};
+
+void install_callbacks_with_memorytracker() {
+    mp::Callbacks cb{};
+
+    cb.onAlloc = [](void* p, std::size_t sz, const char* /*cs*/) {
+        auto cs = mp::currentCallsite();
+        const bool is_array = false;
+        mp::MemoryTracker::instance().onAlloc(
+            p, sz, cs.type_name, cs.file, cs.line, is_array
+        );
+        (void)g_alloc_id.fetch_add(1, std::memory_order_relaxed);
+        mp::clearCallsite();
+    };
+
+    cb.onFree = [](void* p) {
+        const bool is_array = false;
+        mp::MemoryTracker::instance().onFree(p, is_array);
+    };
+
+    cb.bytesInUse = [] { return mp::MemoryTracker::instance().activeBytes(); };
+    cb.peakBytes  = [] { return mp::MemoryTracker::instance().peakBytes();  };
+    cb.allocCount = [] { return mp::MemoryTracker::instance().totalAllocs();};
+
+    cb.snapshot   = [] { return g_snapshot_id.fetch_add(1, std::memory_order_relaxed); };
+
+    cb.liveBlocks = [] {
+        mp::ScopedHookGuard guard;
+        std::vector<BlockInfo> out;
+        auto recs = mp::MemoryTracker::instance().snapshotLive();
+        out.reserve(recs.size());
+        for (const auto& r : recs) {
+            BlockInfo b{};
+            b.ptr       = r.ptr;
+            b.size      = r.size;
+            b.alloc_id  = g_alloc_id.fetch_add(1, std::memory_order_relaxed);
+            b.thread_id = r.thread_id;
+            b.t_ns      = r.timestamp_ns;
+            if (r.file && *r.file) {
+                b.callsite = std::string(r.file) + ":" + std::to_string(r.line);
+            } else {
+                b.callsite = "?:0";
+            }
+            out.push_back(std::move(b));
+        }
+        return out;
+    };
+
+    mp::register_callbacks(cb);
+}
+
+} // namespace mp

--- a/src/Library/core/MemoryTracker.cpp
+++ b/src/Library/core/MemoryTracker.cpp
@@ -1,9 +1,10 @@
 #include "MemoryTracker.hpp"
 #include <new> // std::nothrow (por si se usa en el futuro)
+#include "ReentryGuard.hpp"  // para ScopedHookGuard
 
 namespace mp {
 
-// === Helpers estáticos ===
+// === Helpers estï¿½ticos ===
 uint64_t MemoryTracker::nowNs() {
     using namespace std::chrono;
     return duration_cast<nanoseconds>(steady_clock::now().time_since_epoch()).count();
@@ -21,11 +22,11 @@ MemoryTracker& MemoryTracker::instance() {
     return inst;
 }
 
-// === Registro de asignación ===
+// === Registro de asignaciï¿½n ===
 void MemoryTracker::onAlloc(void* p, std::size_t sz, const char* type,
                             const char* file, int line, bool isArray) {
     if (!p || sz == 0) {
-        // Si malloc devolvió nullptr (o size==0), no registramos.
+        // Si malloc devolviï¿½ nullptr (o size==0), no registramos.
         return;
     }
 
@@ -52,7 +53,7 @@ void MemoryTracker::onAlloc(void* p, std::size_t sz, const char* type,
     }
 }
 
-// === Registro de liberación ===
+// === Registro de liberaciï¿½n ===
 void MemoryTracker::onFree(void* p, bool /*isArray*/) noexcept {
     if (!p) return;
 
@@ -65,7 +66,7 @@ void MemoryTracker::onFree(void* p, bool /*isArray*/) noexcept {
         if (active_allocs_ > 0)  --active_allocs_;
         live_.erase(it);
     }
-    // Importante: no lanzar excepciones aquí.
+    // Importante: no lanzar excepciones aquï¿½.
 }
 
 // === Snapshot de bloques vivos ===
@@ -80,7 +81,7 @@ std::vector<AllocationRecord> MemoryTracker::snapshotLive() const {
     return out;
 }
 
-// === Métricas ===
+// === Mï¿½tricas ===
 std::size_t MemoryTracker::activeBytes() const {
     std::lock_guard<std::mutex> lock(mu_);
     return active_bytes_;

--- a/src/Library/core/OperatorOverrides.cpp
+++ b/src/Library/core/OperatorOverrides.cpp
@@ -1,105 +1,63 @@
 #include "OperatorOverrides.hpp"
-#include "MemoryTracker.hpp"
-#include "Callsite.hpp"      // para obtener file/line/type
-#include "ProfilerAPI.hpp"   // para isSamplingEnabled()
+#include "ProfilerNew.hpp"
+#include "Callbacks.hpp"
+#include "Callsite.hpp"
 
-#include <cstdlib>   // std::malloc, std::free
-#include <new>       // std::bad_alloc
-#include <cstdint>
 
-// Bandera reentrante por hilo (definición)
-namespace mp {
-thread_local bool in_hook = false;
-}
+#include <new>
+#include <cstdlib>
 
-// RAII local para marcar la región del hook
-namespace {
-struct HookScope {
-    bool prev;
-    HookScope() : prev(mp::in_hook) { mp::in_hook = true; }
-    ~HookScope() { mp::in_hook = prev; }
-};
-} // namespace
-
-// --- Overrides globales ---
-// NOTA: usamos malloc/free para evitar dependencia circular con el runtime de new/delete.
-//       Registramos en MemoryTracker sólo cuando NO estamos reentrando.
+// 🔁 Flag de reentrancia visible desde otros TU (p.ej. SocketClient)
+namespace mp { thread_local bool in_hook = false; }
 
 void* operator new(std::size_t sz) {
-    if (mp::in_hook) {
-        void* p = std::malloc(sz ? sz : 1);
-        if (!p) throw std::bad_alloc();
-        return p;
-    }
-
-    HookScope scope;
-    void* p = std::malloc(sz ? sz : 1);
-    if (!p) throw std::bad_alloc();
-
-    // Obtener metadatos desde TLS
-    mp::CallsiteInfo cs = mp::currentCallsite();
-    const char* file = cs.file ? cs.file : "unknown";
-    int         line = cs.line;
-    const char* type = cs.type_name ? cs.type_name : "unknown";
-
-    if (mp::api::isSamplingEnabled()) {
-        mp::MemoryTracker::instance().onAlloc(
-            p, sz, type, file, line, /*is_array=*/false
-        );
-    }
-    return p;
+  if (sz == 0) sz = 1;
+  void* p = std::malloc(sz);
+  if (!p) throw std::bad_alloc{};
+  if (!mp::in_hook) {
+    mp::in_hook = true;
+    const auto& cb = mp::get_callbacks();
+    cb.onAlloc(p, sz, nullptr);
+    mp::in_hook = false;
+  }
+  return p;
 }
 
 void operator delete(void* p) noexcept {
-    if (!p) return;
-
-    if (mp::in_hook) {
-        std::free(p);
-        return;
-    }
-
-    HookScope scope;
-    if (mp::api::isSamplingEnabled()) {
-        mp::MemoryTracker::instance().onFree(p, /*is_array=*/false);
-    }
-    std::free(p);
+  if (!p) return;
+  if (!mp::in_hook) {
+    mp::in_hook = true;
+    const auto& cb = mp::get_callbacks();
+    cb.onFree(p);
+    mp::in_hook = false;
+  }
+  std::free(p);
 }
 
 void* operator new[](std::size_t sz) {
-    if (mp::in_hook) {
-        void* p = std::malloc(sz ? sz : 1);
-        if (!p) throw std::bad_alloc();
-        return p;
-    }
-
-    HookScope scope;
-    void* p = std::malloc(sz ? sz : 1);
-    if (!p) throw std::bad_alloc();
-
-    mp::CallsiteInfo cs = mp::currentCallsite();
-    const char* file = cs.file ? cs.file : "unknown";
-    int         line = cs.line;
-    const char* type = cs.type_name ? cs.type_name : "unknown";
-
-    if (mp::api::isSamplingEnabled()) {
-        mp::MemoryTracker::instance().onAlloc(
-            p, sz, type, file, line, /*is_array=*/true
-        );
-    }
-    return p;
+  if (sz == 0) sz = 1;
+  void* p = std::malloc(sz);
+  if (!p) throw std::bad_alloc{};
+  if (!mp::in_hook) {
+    mp::in_hook = true;
+    const auto& cb = mp::get_callbacks();
+    cb.onAlloc(p, sz, nullptr);
+    mp::in_hook = false;
+  }
+  return p;
 }
 
 void operator delete[](void* p) noexcept {
-    if (!p) return;
-
-    if (mp::in_hook) {
-        std::free(p);
-        return;
-    }
-
-    HookScope scope;
-    if (mp::api::isSamplingEnabled()) {
-        mp::MemoryTracker::instance().onFree(p, /*is_array=*/true);
-    }
-    std::free(p);
+  if (!p) return;
+  if (!mp::in_hook) {
+    mp::in_hook = true;
+    const auto& cb = mp::get_callbacks();
+    cb.onFree(p);
+    mp::in_hook = false;
+  }
+  std::free(p);
 }
+
+// Sized delete para silenciar warnings
+void operator delete(void* p, std::size_t) noexcept { operator delete(p); }
+void operator delete[](void* p, std::size_t) noexcept { operator delete[](p); }

--- a/src/Library/core/SocketClient.cpp
+++ b/src/Library/core/SocketClient.cpp
@@ -2,6 +2,7 @@
 #include "ProfilerAPI.hpp"    // mp::api::{getMetricsJson,getSnapshotJson}
 #include "Callsite.hpp"       // anti-reentrancy flag lives in this namespace
 
+
 #include <atomic>
 #include <chrono>
 #include <cstring>

--- a/src/Library/include/BlockInfo.hpp
+++ b/src/Library/include/BlockInfo.hpp
@@ -1,8 +1,18 @@
-//
-// Created by PC MASTER on 8/25/2025.
-//
+#pragma once
+#include <cstddef>
+#include <cstdint>
+#include <string>
 
-#ifndef MEMORY_PROFILER_BLOCKINFO_HPP
-#define MEMORY_PROFILER_BLOCKINFO_HPP
+namespace mp {
 
-#endif //MEMORY_PROFILER_BLOCKINFO_HPP
+// DTO público que usa Serializer.{csv,json}
+struct BlockInfo {
+    void*         ptr        = nullptr;
+    std::size_t   size       = 0;
+    std::uint64_t alloc_id   = 0;
+    std::uint32_t thread_id  = 0;
+    std::uint64_t t_ns       = 0;
+    std::string   callsite;            // "file:line[:func]"
+};
+
+} // namespace mp

--- a/src/Library/include/Callbacks.hpp
+++ b/src/Library/include/Callbacks.hpp
@@ -1,0 +1,29 @@
+#pragma once
+#include <functional>
+#include <vector>
+#include <cstdint>
+#include "BlockInfo.hpp"
+
+namespace mp {
+
+struct Callbacks {
+  // callsite puede ser nullptr si el modelo no lo usa
+  std::function<void(void*, std::size_t, const char*)> onAlloc;
+  std::function<void(void*)>                           onFree;
+
+  std::function<std::size_t()> bytesInUse;
+  std::function<std::size_t()> peakBytes;
+  std::function<std::size_t()> allocCount;
+
+  std::function<std::uint64_t()>          snapshot;
+  std::function<std::vector<BlockInfo>()> liveBlocks;
+
+  std::uint32_t version = 1;
+};
+
+void register_callbacks(const Callbacks& c);
+
+// Siempre devuelve callbacks válidos (no-op si no han registrado)
+const Callbacks& get_callbacks();
+
+} // namespace mp

--- a/src/Library/include/OperatorOverrides.hpp
+++ b/src/Library/include/OperatorOverrides.hpp
@@ -1,26 +1,7 @@
 #pragma once
 #include <cstddef>
 
-//
-// Macros de captura (por ahora placeholders)
-//
-#define MP_ALLOC_TYPE(t) #t
-#define MP_FILE __FILE__
-#define MP_LINE __LINE__
-
-namespace mp {
-
-// Bandera reentrante (un valor por hilo). Definición en OperatorOverrides.cpp
-extern thread_local bool in_hook;
-
-// Guard de conveniencia para desactivar el registro dentro de una sección
-struct ScopedHookGuard {
-    bool prev;
-    ScopedHookGuard() : prev(in_hook) { in_hook = true; }
-    ~ScopedHookGuard() { in_hook = prev; }
-};
-
-} // namespace mp
-
-// Declaraciones de los overrides globales (definidos en OperatorOverrides.cpp)
-// Nota: no necesitas incluir nada especial para usarlos; al linkear la lib quedan activos.
+void* operator new(std::size_t sz);
+void  operator delete(void* p) noexcept;
+void* operator new[](std::size_t sz);
+void  operator delete[](void* p) noexcept;

--- a/src/Library/include/ProfilerNew.hpp
+++ b/src/Library/include/ProfilerNew.hpp
@@ -1,29 +1,9 @@
 // src/Library/include/ProfilerNew.hpp
 #pragma once
-#include <typeinfo>
 #include "Callsite.hpp"
+#include <typeinfo>
 
-// --- USO BÁSICO (sin metadatos) ---
-#define MP_NEW(T, ...)               new T(__VA_ARGS__)
-#define MP_NEW_ARRAY(T, N)           new T[N]
+#define MP_NEW_FT(T, ...) ( mp::ScopedCallsite(__FILE__, __LINE__, typeid(T).name()), new T(__VA_ARGS__) )
 
-// --- CAPTURA __FILE__ y __LINE__ (una sola expresión gracias a lambda) ---
-#define MP_NEW_F(T, ...) \
-    ([&](){ ::mp::ScopedCallsite _mp_sc(__FILE__, __LINE__); return new T(__VA_ARGS__); }())
-
-#define MP_NEW_ARRAY_F(T, N) \
-    ([&](){ ::mp::ScopedCallsite _mp_sc(__FILE__, __LINE__); return new T[N]; }())
-
-// --- CAPTURA type_name (posiblemente mangleado) ---
-#define MP_NEW_T(T, ...) \
-    ([&](){ ::mp::ScopedCallsite _mp_sc(nullptr, 0, typeid(T).name()); return new T(__VA_ARGS__); }())
-
-#define MP_NEW_ARRAY_T(T, N) \
-    ([&](){ ::mp::ScopedCallsite _mp_sc(nullptr, 0, typeid(T).name()); return new T[N]; }())
-
-// --- CAPTURA TODO: file, line y type_name (RECOMENDADO) ---
-#define MP_NEW_FT(T, ...) \
-    ([&](){ ::mp::ScopedCallsite _mp_sc(__FILE__, __LINE__, typeid(T).name()); return new T(__VA_ARGS__); }())
-
-#define MP_NEW_ARRAY_FT(T, N) \
-    ([&](){ ::mp::ScopedCallsite _mp_sc(__FILE__, __LINE__, typeid(T).name()); return new T[N]; }())
+#define MP_SET_CALLSITE()   ::mp::setCallsite(__FILE__, __LINE__)
+#define MP_SET_TYPENAME(T)  ::mp::setTypeName(typeid(T).name())

--- a/src/Library/include/ReentryGuard.hpp
+++ b/src/Library/include/ReentryGuard.hpp
@@ -1,0 +1,10 @@
+#pragma once
+namespace mp { extern thread_local bool in_hook; }
+
+namespace mp {
+struct ScopedHookGuard {
+    bool prev{};
+    ScopedHookGuard() : prev(mp::in_hook) { mp::in_hook = true; }
+    ~ScopedHookGuard() { mp::in_hook = prev; }
+};
+} // namespace mp

--- a/src/Library/include/Serializer.hpp
+++ b/src/Library/include/Serializer.hpp
@@ -1,14 +1,25 @@
 #pragma once
 #include <string>
 #include <vector>
-#include "MemoryTracker.hpp"
+#include <cstdint>
+#include "BlockInfo.hpp"
+//#include "BlockInfo.cpp"
+namespace mp {
 
-namespace mp::serialize {
+  // JSON plano: {"bytes_in_use":X,"peak":Y,"alloc_count":Z}
+  std::string make_summary_json(std::size_t bytes_in_use,
+                                std::size_t peak,
+                                std::size_t alloc_count);
 
-// Serializa métricas básicas a un JSON sencillo (sin libs externas)
-std::string metricsJson(const MemoryTracker& tracker);
+  // CSV plano (encabezado estable)
+  // ptr,size,alloc_id,thread_id,t_ns,callsite
+  std::string make_live_allocs_csv(const std::vector<BlockInfo>& blocks);
 
-// Serializa un snapshot de bloques vivos a JSON sencillo
-std::string snapshotJson(const std::vector<AllocationRecord>& records);
+  // JSON: {"blocks":[{...}, ...]}
+  std::string make_live_allocs_json(const std::vector<BlockInfo>& blocks);
 
-} // namespace mp::serialize
+  // Envoltura para GUI: {"type":"TYPE","payload":{...}}
+  // payload_object_json DEBE ser un objeto JSON (sin comillas externas)
+  std::string make_message_json(const char* type, const std::string& payload_object_json);
+
+} // namespace mp


### PR DESCRIPTION
Incluye:
- Implementación de MemoryTracker con métricas activas, picos y snapshot de bloques vivos.
- Estructura AllocationRecord con metadatos (file, line, thread_id, timestamp, etc.).
- Macros en ProfilerNew.hpp para capturar callsite real (file/line/type).
- Funciones JSON/CSV para exportar métricas y snapshots.
- Ejemplo demo.cpp con SocketClient y simulación de asignaciones/liberaciones.
- Pruebas de integración vía netcat (nc) mostrando SUMMARY y SNAPSHOT en JSON.

Pendiente: afinar macros y probar integración de la librería en proyectos externos.