### PR TITLE
Fix qapplication header not found error

### DIFF
--- a/src/GUI/core/main.cpp
+++ b/src/GUI/core/main.cpp
@@ -1,4 +1,4 @@
-#include <QApplication>
+#include <QtWidgets/QApplication>
 #include "../include/MainWindow.hpp"
 #include "../Library/include/CallbacksRegistration.hpp"
 


### PR DESCRIPTION
Update QApplication include to use the explicit QtWidgets module path.

---
<a href="https://cursor.com/background-agent?bcId=bc-aee9c5a0-483e-4416-b043-47d4742882f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-aee9c5a0-483e-4416-b043-47d4742882f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

